### PR TITLE
Update PI4 IO Expander Initialization to Set Speaker Control IO as Output

### DIFF
--- a/src/M5EchoBase.cpp
+++ b/src/M5EchoBase.cpp
@@ -188,7 +188,7 @@ bool M5EchoBase::pi4ioe_init()
 
     // Enable pull-up resistors
     wire_write_byte(PI4IOE_ADDR, PI4IOE_REG_IO_PULLUP, 0xFF);  // Enable pull-up
-    wire_write_byte(PI4IOE_ADDR, PI4IOE_REG_IO_DIR, 0x6E);     // Set input=0, output=1
+    wire_write_byte(PI4IOE_ADDR, PI4IOE_REG_IO_DIR, 0x6F);     // Set input=0, output=1, set P0 as output
     wire_read_byte(PI4IOE_ADDR, PI4IOE_REG_IO_DIR);
 
     // Set outputs to 1


### PR DESCRIPTION
This PR modifies the initialization parameters for the PI4IOE5V6408ZTAEX IO expander. The direction register is now configured to set the IO pin corresponding to the speaker control as output mode. This ensures proper control of the speaker via the IO expander.（0x6E -> 0x6F）
- Updated the value written to the direction register during initialization.
- Added comments to reflect the correct IO direction settings.

